### PR TITLE
Use contracts that don't require extra gas.

### DIFF
--- a/src/config/testnet.json
+++ b/src/config/testnet.json
@@ -1,5 +1,5 @@
 {
-  "safeSingletonAddress": "0xffd41b816f2821e579b4da85c7352bf4f17e4fa5",
-  "proxyFactoryAddress": "0x5b836117aed4ca4dee8e2e464f97f7f59b426c5a",
+  "safeSingletonAddress": "0xf95323ab9b3b439a3542e064ab1da1e398deca24",
+  "proxyFactoryAddress": "0x639c9abf487526c3d747964af8023770c28be9e6",
   "rifToken": "0x19f64674d8a5b4e652319f5e239efd3bc969a1fe"
 }


### PR DESCRIPTION
A different approach than #17 where the contracts that are deployed do not require the execution to include +30k gas. 