### PR TITLE
Local storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ConnectedBar from './components/ConnectedBar'
 import SafeInteraction from './pages/safeInteraction'
 import ChooseSafe from './pages/connectToSafe'
 import FooterComponent from './components/FooterComponent'
+import { saveSafeAddresToLocalStorage } from './helpers/localStorage'
 
 const rLogin = new RLogin({
   cacheProvider: false,
@@ -37,6 +38,7 @@ function App () {
   const handleSetSafe = (safe: Safe) => {
     setSafe(safe)
     handleError(null)
+    saveSafeAddresToLocalStorage(safe.getAddress())
   }
 
   const handleError = (error: Error | null) => error ? setError(error.message) : setError(null)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function App () {
   const handleSetSafe = (safe: Safe) => {
     setSafe(safe)
     handleError(null)
-    saveSafeAddresToLocalStorage(safe.getAddress())
+    chainId && saveSafeAddresToLocalStorage(safe.getAddress(), chainId)
   }
 
   const handleError = (error: Error | null) => error ? setError(error.message) : setError(null)

--- a/src/helpers/localStorage.ts
+++ b/src/helpers/localStorage.ts
@@ -36,5 +36,5 @@ export const saveTransactionsToLocalStorage = (transactions: TransactionBundle[]
 
 export const getTransactionsFromLocalStorage = (safeAddress: string) => {
   const content = localStorage.getItem(`${LocalStorageKeys.TRANSACTIONS}_${safeAddress.toLowerCase()}`)
-  return content ? serviceToBundles(JSON.parse(content)) : null
+  return content ? serviceToBundles(JSON.parse(content), safeAddress) : null
 }

--- a/src/helpers/localStorage.ts
+++ b/src/helpers/localStorage.ts
@@ -1,27 +1,40 @@
+import { TransactionBundle } from '../pages/safeInteraction'
+import { bundleToServiceArray, serviceToBundles } from './serviceAdapter'
+
 /* eslint-disable no-unused-vars */
 export enum LocalStorageKeys {
   SAFES = 'SAFES',
   TRANSACTIONS = 'TRANSACTIONS'
 }
 
-const setKey = (key: LocalStorageKeys, value: string) =>
+const setKey = (key: string, value: string) =>
   localStorage.setItem(key, value)
 
-const setJsonKey = (key: LocalStorageKeys, value: any) =>
-  setKey(key, JSON.stringify(value))
+const setJsonKey = (key: LocalStorageKeys, chainId: number, value: any) =>
+  setKey(`${key}_${chainId.toString()}`, JSON.stringify(value))
 
-export const getKey = (key: LocalStorageKeys) => {
-  const content = localStorage.getItem(key)
+export const getKey = (key: LocalStorageKeys, chainId: number) => {
+  const content = localStorage.getItem(`${key}_${chainId.toString()}`)
   return content ? JSON.parse(content) : null
 }
 
-export const saveSafeAddresToLocalStorage = (safeAddress: string) => {
-  const safes = getKey(LocalStorageKeys.SAFES) as string[]
+export const saveSafeAddresToLocalStorage = (safeAddress: string, chainId: number) => {
+  const safes = getKey(LocalStorageKeys.SAFES, chainId)
   if (!safes) {
-    return setJsonKey(LocalStorageKeys.SAFES, [safeAddress.toLowerCase()])
+    return setJsonKey(LocalStorageKeys.SAFES, chainId, [safeAddress.toLowerCase()])
   }
 
   return !safes.includes(safeAddress.toLowerCase())
-    ? setJsonKey(LocalStorageKeys.SAFES, [...safes, safeAddress.toLowerCase()])
+    ? setJsonKey(LocalStorageKeys.SAFES, chainId, [...safes, safeAddress.toLowerCase()])
     : null
+}
+
+export const saveTransactionsToLocalStorage = (transactions: TransactionBundle[], safeAddress: string) => {
+  const converted = bundleToServiceArray(transactions, safeAddress)
+  setKey(`${LocalStorageKeys.TRANSACTIONS}_${safeAddress.toLowerCase()}`, JSON.stringify(converted))
+}
+
+export const getTransactionsFromLocalStorage = (safeAddress: string) => {
+  const content = localStorage.getItem(`${LocalStorageKeys.TRANSACTIONS}_${safeAddress.toLowerCase()}`)
+  return content ? serviceToBundles(JSON.parse(content)) : null
 }

--- a/src/helpers/localStorage.ts
+++ b/src/helpers/localStorage.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-unused-vars */
+export enum LocalStorageKeys {
+  SAFES = 'SAFES',
+  TRANSACTIONS = 'TRANSACTIONS'
+}
+
+const setKey = (key: LocalStorageKeys, value: string) =>
+  localStorage.setItem(key, value)
+
+const setJsonKey = (key: LocalStorageKeys, value: any) =>
+  setKey(key, JSON.stringify(value))
+
+export const getKey = (key: LocalStorageKeys) => {
+  const content = localStorage.getItem(key)
+  return content ? JSON.parse(content) : null
+}
+
+export const saveSafeAddresToLocalStorage = (safeAddress: string) => {
+  const safes = getKey(LocalStorageKeys.SAFES) as string[]
+  if (!safes) {
+    return setJsonKey(LocalStorageKeys.SAFES, [safeAddress.toLowerCase()])
+  }
+
+  return !safes.includes(safeAddress.toLowerCase())
+    ? setJsonKey(LocalStorageKeys.SAFES, [...safes, safeAddress.toLowerCase()])
+    : null
+}

--- a/src/helpers/serviceAdapter.ts
+++ b/src/helpers/serviceAdapter.ts
@@ -44,7 +44,7 @@ export const bundleToService = (bundle: TransactionBundle, safeAddress: string) 
   return response
 }
 
-export const serviceToBundle = (transaction: TransactionServiceResponse) => {
+export const serviceToBundle = (transaction: TransactionServiceResponse, safeAddress: string) => {
   const safeTransaction = new SafeTransaction({
     to: transaction.to,
     value: transaction.value,
@@ -58,11 +58,13 @@ export const serviceToBundle = (transaction: TransactionServiceResponse) => {
     refundReceiver: transaction.refundReceiver || ''
   })
 
+  const isReject = (transaction.to === safeAddress && transaction.value === '0' && transaction.data === '0x')
+
   const bundle:TransactionBundle = ({
     transaction: safeTransaction,
     status: transaction.isExecuted ? TransactionStatus.EXECUTED : TransactionStatus.PENDING,
     hash: transaction.safeTxHash,
-    isReject: false // @todo: figure out how a REJECTED tranasction is encoded.
+    isReject
   })
 
   return bundle
@@ -74,8 +76,8 @@ export const bundleToServiceArray = (bundles: TransactionBundle[], safeAddress: 
   return serviceArray
 }
 
-export const serviceToBundles = (serviceResponse: TransactionServiceResponse[]) => {
+export const serviceToBundles = (serviceResponse: TransactionServiceResponse[], safeAddress: string) => {
   const bundles: TransactionBundle[] = []
-  serviceResponse.map((response: TransactionServiceResponse) => bundles.push(serviceToBundle(response)))
+  serviceResponse.map((response: TransactionServiceResponse) => bundles.push(serviceToBundle(response, safeAddress)))
   return bundles
 }

--- a/src/helpers/serviceAdapter.ts
+++ b/src/helpers/serviceAdapter.ts
@@ -1,0 +1,81 @@
+// Adapter between the transaction service (and localStorage) and this app
+
+import { SafeTransaction } from '@gnosis.pm/safe-core-sdk'
+import { TransactionStatus } from '../constants'
+import { TransactionBundle } from '../pages/safeInteraction'
+
+// source: https://docs.gnosis.io/safe/docs/services_transactions/
+interface TransactionServiceResponse {
+  'safe': string, // '<address>',
+  'to': string, // '<address>',
+  'value': string, // '<stringified-int>',
+  'data': string, // '<hex>',
+  'operation': number, // '<int>',
+  'gasToken': string, // '<address>',
+  'safeTxGas': string, // '<stringified-int>',
+  'baseGas': string, // '<stringified-int>',
+  'gasPrice': string, // '<stringified-int>',
+  'refundReceiver'?: string, // '<address>',
+  'nonce': number, // '<int>',
+  'safeTxHash': string, // '<hex>',
+  'blockNumber'?: number, // '<int>',
+  'transactionHash'?: string, // '<hex>',
+  'submissionDate'?: string, // '<string>',
+  'isExecuted': boolean // '<bool>',
+  'isSuccesful': boolean // '<bool>',
+  'executionDate'?: string, // '<string>',
+  'executor'?: string, // '<address>',
+  'confirmations'?: string[], // ['<address>'],
+  'signatures'?: string, // '<hex>'
+}
+
+export const bundleToService = (bundle: TransactionBundle, safeAddress: string) => {
+  const response:TransactionServiceResponse = {
+    safe: safeAddress,
+    ...bundle.transaction.data,
+    safeTxGas: bundle.transaction.data.safeTxGas.toString(),
+    baseGas: bundle.transaction.data.baseGas.toString(),
+    gasPrice: bundle.transaction.data.gasPrice.toString(),
+    safeTxHash: bundle.hash,
+    isExecuted: bundle.status === TransactionStatus.EXECUTED,
+    isSuccesful: bundle.status === TransactionStatus.EXECUTED
+  }
+
+  return response
+}
+
+export const serviceToBundle = (transaction: TransactionServiceResponse) => {
+  const safeTransaction = new SafeTransaction({
+    to: transaction.to,
+    value: transaction.value,
+    data: transaction.data,
+    safeTxGas: parseInt(transaction.safeTxGas),
+    baseGas: parseInt(transaction.baseGas),
+    gasPrice: parseInt(transaction.gasPrice),
+    nonce: transaction.nonce,
+    operation: transaction.operation,
+    gasToken: transaction.gasToken,
+    refundReceiver: transaction.refundReceiver || ''
+  })
+
+  const bundle:TransactionBundle = ({
+    transaction: safeTransaction,
+    status: transaction.isExecuted ? TransactionStatus.EXECUTED : TransactionStatus.PENDING,
+    hash: transaction.safeTxHash,
+    isReject: false // @todo: figure out how a REJECTED tranasction is encoded.
+  })
+
+  return bundle
+}
+
+export const bundleToServiceArray = (bundles: TransactionBundle[], safeAddress: string) => {
+  const serviceArray: TransactionServiceResponse[] = []
+  bundles.map((bundle: TransactionBundle) => serviceArray.push(bundleToService(bundle, safeAddress)))
+  return serviceArray
+}
+
+export const serviceToBundles = (serviceResponse: TransactionServiceResponse[]) => {
+  const bundles: TransactionBundle[] = []
+  serviceResponse.map((response: TransactionServiceResponse) => bundles.push(serviceToBundle(response)))
+  return bundles
+}

--- a/src/pages/connectToSafe/ConnectToSafeComponent.tsx
+++ b/src/pages/connectToSafe/ConnectToSafeComponent.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import { getKey, LocalStorageKeys } from '../../helpers/localStorage'
 
 interface Interface {
   connectToSafe: (safeAddress: string) => void
@@ -6,6 +7,11 @@ interface Interface {
 
 const ConnectToSafeComponent: React.FC<Interface> = ({ connectToSafe }) => {
   const [safeAddress, setSafeAddress] = useState<string>('')
+  const [pastSafes, setPastSafes] = useState<string[]>([])
+
+  useEffect(() => {
+    setPastSafes(getKey(LocalStorageKeys.SAFES))
+  }, [])
 
   return (
     <div>
@@ -13,6 +19,22 @@ const ConnectToSafeComponent: React.FC<Interface> = ({ connectToSafe }) => {
       <label>Safe address</label>
       <input className="safeAddress" type="text" value={safeAddress} onChange={evt => setSafeAddress(evt.target.value)} />
       <button className="connect" onClick={() => connectToSafe(safeAddress)}>Connect</button>
+
+      {pastSafes && pastSafes.length !== 0 && (
+        <>
+          <h4>Past Safes:</h4>
+          <ul>
+            {pastSafes.map((address: string) => (
+              <li key={address}>
+                <button
+                  className="icon"
+                  onClick={() => connectToSafe(address)}>{address}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </div>
   )
 }

--- a/src/pages/connectToSafe/ConnectToSafeComponent.tsx
+++ b/src/pages/connectToSafe/ConnectToSafeComponent.tsx
@@ -1,17 +1,12 @@
-import React, { useEffect, useState } from 'react'
-import { getKey, LocalStorageKeys } from '../../helpers/localStorage'
+import React, { useState } from 'react'
 
 interface Interface {
   connectToSafe: (safeAddress: string) => void
+  pastSafes: string[]
 }
 
-const ConnectToSafeComponent: React.FC<Interface> = ({ connectToSafe }) => {
+const ConnectToSafeComponent: React.FC<Interface> = ({ connectToSafe, pastSafes }) => {
   const [safeAddress, setSafeAddress] = useState<string>('')
-  const [pastSafes, setPastSafes] = useState<string[]>([])
-
-  useEffect(() => {
-    setPastSafes(getKey(LocalStorageKeys.SAFES))
-  }, [])
 
   return (
     <div>

--- a/src/pages/connectToSafe/index.tsx
+++ b/src/pages/connectToSafe/index.tsx
@@ -50,7 +50,7 @@ const ChooseSafe: React.FC<Interface> = ({ web3Provider, chainId, handleSetSafe,
     const signer = provider.getSigner()
 
     EthersSafe.create(ethers, safeAddress.toLowerCase(), signer)
-      .then((safe: any) => handleSetSafe(safe))
+      .then(handleSetSafe)
       .catch(handleError)
       .finally(() => setIsLoading(false))
   }

--- a/src/pages/connectToSafe/index.tsx
+++ b/src/pages/connectToSafe/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import EthersSafe, { Safe } from '@gnosis.pm/safe-core-sdk'
 import { EthersSafeFactory } from '@rsksmart/safe-factory-sdk'
 import { ethers } from 'ethers'
@@ -7,6 +7,7 @@ import CreateSafeComponent from './CreateSafeComponent'
 import ConnectToSafeComponent from './ConnectToSafeComponent'
 import { getContracts } from '../../config'
 import LoadingComponent from '../../components/LoadingComponent'
+import { getKey, LocalStorageKeys } from '../../helpers/localStorage'
 
 interface Interface {
   web3Provider: any
@@ -20,6 +21,9 @@ const ChooseSafe: React.FC<Interface> = ({ web3Provider, chainId, handleSetSafe,
   // UI variables
   const [isCreate, setIsCreate] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [pastSafes, setPastSafes] = useState<string[]>([])
+
+  useEffect(() => { setPastSafes(getKey(LocalStorageKeys.SAFES, chainId)) }, [])
 
   // Create a new safe:
   const createSafe = (addresses: string[], threshold: number) => {
@@ -72,6 +76,7 @@ const ChooseSafe: React.FC<Interface> = ({ web3Provider, chainId, handleSetSafe,
           />
         ) : (
           <ConnectToSafeComponent
+            pastSafes={pastSafes}
             connectToSafe={connectToSafe}
           />
         )}

--- a/src/pages/safeInteraction/index.tsx
+++ b/src/pages/safeInteraction/index.tsx
@@ -39,7 +39,11 @@ const SafeInteraction: React.FC<Interface> = ({ safe, walletAddress, handleError
 
       if (nonce !== 0) {
         const serviceResponse = getTransactionsFromLocalStorage(safe.getAddress())
-        serviceResponse && setTransactions(serviceResponse)
+        if (serviceResponse) {
+          setTransactions(serviceResponse)
+          // set the App's nonce to the last transaction's nonce +1:
+          setAppNonce(serviceResponse[serviceResponse.length - 1].transaction.data.nonce + 1)
+        }
       }
     })
   }, [safe])


### PR DESCRIPTION
Save safe addresses and transactions to localStorage. Use a similar format to the transaction service to make that easier to implement in the future. 

Closes #16